### PR TITLE
Anteslashes must be escaped in BASH/SH

### DIFF
--- a/Resources/doc/loaders.md
+++ b/Resources/doc/loaders.md
@@ -125,7 +125,7 @@ services:
 A Symfony command is ready in this bundle, which can be used to execute a specific loader:
 
 ```bash
-php bin/console migration:load MigrationBundle\Loader\UserLoader
+php bin/console migration:load 'MigrationBundle\Loader\UserLoader'
 ```
 
 ## Use an alias


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets | n/a
| License       | MIT

